### PR TITLE
Expose the underlying error message when the TP-Link API returns an unknown error

### DIFF
--- a/src/api.test.ts
+++ b/src/api.test.ts
@@ -1,4 +1,4 @@
-import { cloudLogin, listDevices, listDevicesByType, loginDevice, loginDeviceByIp, getDeviceInfo, turnOn, setBrightness, setColour } from './api';
+import { cloudLogin, listDevices, listDevicesByType, loginDevice, loginDeviceByIp, getDeviceInfo, turnOn, setBrightness, setColour, checkError } from './api';
 
 const email = "<TP LINK ACCOUNT EMAIL>";
 const password = "<TP LINK ACCOUNT PASSWORD>";
@@ -69,5 +69,14 @@ xtest('Set bulb colour', async () => {
     await turnOn(deviceToken);
     await setBrightness(deviceToken, 75);
     await setColour(deviceToken, 'warmwhite');
+});
+
+test('Handle unknown error, throwing a helpful error message', async () => {
+    expect(() => {
+        checkError({
+            error_code: -20004,
+            msg: "API rate limit exceeded"
+        })
+    }).toThrow('Unexpected Error Code: -20004 (API rate limit exceeded)')
 });
 

--- a/src/api.ts
+++ b/src/api.ts
@@ -198,7 +198,7 @@ export const isTapoDevice = (deviceType: string) => {
   }
 }
 
-const checkError = (responseData: any) => {
+export const checkError = (responseData: any) => {
   const errorCode = responseData["error_code"];
   if (errorCode) {
     switch (errorCode) {
@@ -210,7 +210,7 @@ const checkError = (responseData: any) => {
       case -20601: throw new Error("Incorrect email or password");
       case -20675: throw new Error("Cloud token expired or invalid");
       case 9999: throw new Error("Device token expired or invalid");
-      default: throw new Error(`Unexpected Error Code: ${errorCode}`);
+      default: throw new Error(`Unexpected Error Code: ${errorCode} (${responseData["msg"]})`);
     }
     
   }


### PR DESCRIPTION
This improves the handling of unknown errors returned by TPLink, including the error message in the thrown error as well as the error code.

Just seeing a code is rather opaque and you end up having to add debugging code into the library to actually see what came back. Exposing the message avoids this.