### PR TITLE
Update `local-devices` dependency to `v4.0.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "axios": "^0.21.4",
-        "local-devices": "^3.2.0",
+        "local-devices": "^4.0.0",
         "uuid": "^8.3.2"
       },
       "devDependencies": {
@@ -3733,9 +3733,9 @@
       "dev": true
     },
     "node_modules/local-devices": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/local-devices/-/local-devices-3.2.0.tgz",
-      "integrity": "sha512-JkWPXdFbu0l4nPXtINrcz8fkLA0WLMopmsHLvYsOMLnFx1SUM5cTVlLz6ZXcYMZHzWXoy0pOreKKLzsWBq5muQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/local-devices/-/local-devices-4.0.0.tgz",
+      "integrity": "sha512-65EPltZW7bPRTmIiL9yuQcu0Om6dYl4dzRgiIYxl/cUO62FBW09ZpIVtpffXU8vryfGXEXxt68oWK/Kru12FEA==",
       "dependencies": {
         "get-ip-range": "^2.1.0",
         "ip": "^1.1.5",
@@ -9237,9 +9237,9 @@
       "dev": true
     },
     "local-devices": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/local-devices/-/local-devices-3.2.0.tgz",
-      "integrity": "sha512-JkWPXdFbu0l4nPXtINrcz8fkLA0WLMopmsHLvYsOMLnFx1SUM5cTVlLz6ZXcYMZHzWXoy0pOreKKLzsWBq5muQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/local-devices/-/local-devices-4.0.0.tgz",
+      "integrity": "sha512-65EPltZW7bPRTmIiL9yuQcu0Om6dYl4dzRgiIYxl/cUO62FBW09ZpIVtpffXU8vryfGXEXxt68oWK/Kru12FEA==",
       "requires": {
         "get-ip-range": "^2.1.0",
         "ip": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "axios": "^0.21.4",
-    "local-devices": "^3.2.0",
+    "local-devices": "^4.0.0",
     "uuid": "^8.3.2"
   }
 }

--- a/src/network-tools.ts
+++ b/src/network-tools.ts
@@ -1,8 +1,7 @@
 import find from 'local-devices'
 
 export const resolveMacToIp = async (mac: string) :Promise<string> => {
-    //@ts-ignore
-    const devices = await find(null, true);
+    const devices = await find({ skipNameResolution: true });
     return devices.find(device => tidyMac(device.mac) == tidyMac(mac)).ip
 }
 


### PR DESCRIPTION
This updates the `local-devices` package which we depend on to its latest version, v4.0.0. This version includes breaking changes to the function definition, so we also adapt our code to those changes.