### PR TITLE
Change throw new Error to console.error for colour changes.

### DIFF
--- a/src/colour-helper.ts
+++ b/src/colour-helper.ts
@@ -84,5 +84,5 @@ export const getColour = (colour: string) => {
   if (colour.startsWith('#')) return hexToHsl(colour);
   if (colour.endsWith('k')) return temperature(colour);
   if (Object.keys(presetColours).includes(colour)) return presetColours[colour];
-  throw new Error('Invalid Colour');
+  console.error('Invalid Colour');
 }


### PR DESCRIPTION
Discord BOT or similar apps stop running when throw is used. For colour changes we can use console.error for invalid color it's better to just notify user that it's not valid. But throw is stopping app and needs a restart.

I was not able to find 