### PR TITLE
Change appType used for cloud login from "Tapo_Android" to "Tapo_Ios"…

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -36,7 +36,7 @@ export const cloudLogin = async (email: string = process.env.TAPO_USERNAME || un
   const loginRequest = {
     "method": "login",
     "params": {
-      "appType": "Tapo_Android",
+      "appType": "Tapo_Ios",
       "cloudPassword": password,
       "cloudUserName": email,
       "terminalUUID": uuidv4()


### PR DESCRIPTION
This, for whatever reason known only to TP Link, fixes #55

Will it continue to work? What are TP Link's API plans? Sorry, don't know. But hope this is helpful.